### PR TITLE
niv motoko-base: update c2653954 -> 58b81f62 (#3456)

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -64,10 +64,10 @@
         "homepage": null,
         "owner": "dfinity",
         "repo": "motoko-base",
-        "rev": "c2653954c04d6ec06804404472e6e497e867fb47",
-        "sha256": "1hjjm95av6g0ff2440vml9imgqa5k2s8n45vj6aa1ckrdji2w349",
+        "rev": "58b81f62eaaf6e5a1afbc39abe27855467fb49b3",
+        "sha256": "0ns15g605fw9p8bi89h41hlw3q7qbj29362yhn8ccpy1bngah207",
         "type": "tarball",
-        "url": "https://github.com/dfinity/motoko-base/archive/c2653954c04d6ec06804404472e6e497e867fb47.tar.gz",
+        "url": "https://github.com/dfinity/motoko-base/archive/58b81f62eaaf6e5a1afbc39abe27855467fb49b3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "motoko-matchers": {


### PR DESCRIPTION
## Changelog for motoko-base:
Branch: next-moc
Commits: [dfinity/motoko-base@c2653954...58b81f62](https://github.com/dfinity/motoko-base/compare/c2653954c04d6ec06804404472e6e497e867fb47...58b81f62eaaf6e5a1afbc39abe27855467fb49b3)

* [`08507fc9`](https://github.com/dfinity/motoko-base/commit/08507fc9dc425144242434b8fa762c3287077335) bump `vessel` ([dfinity/motoko-base⁠#415](https://togithub.com/dfinity/motoko-base/issues/415))